### PR TITLE
Rename epel dependency references

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 
 dependencies:
-  - { role: ansible_uclalib_role_epel }
+  - { role: uclalib_role_epel }

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,2 +1,2 @@
-- name: ansible_uclalib_role_epel
-  src: https://github.com/uclalibrary/ansible_uclalib_role_epel
+- name: uclalib_role_epel
+  src: https://github.com/uclalibrary/uclalib_role_epel

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,5 +3,5 @@
 - hosts: all
 
   roles:
-    - ansible_uclalib_role_epel
+    - uclalib_role_epel
     - uclalib_role_awscli


### PR DESCRIPTION
Once the epel ansible role has been renamed, we need to update our references to it in this role too.